### PR TITLE
Begin implementation of type configuration

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,9 +13,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
     "Type" : "Generic::Vault::Secret",
     "Properties" : {
         "<a href="#secretpath" title="SecretPath">SecretPath</a>" : <i>String</i>,
-        "<a href="#server" title="Server">Server</a>" : <i>String</i>,
         "<a href="#secretenginemountpath" title="SecretEngineMountPath">SecretEngineMountPath</a>" : <i>String</i>,
-        "<a href="#token" title="Token">Token</a>" : <i>String</i>,
         "<a href="#secretlength" title="SecretLength">SecretLength</a>" : <i>Integer</i>,
     }
 }
@@ -27,9 +25,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 Type: Generic::Vault::Secret
 Properties:
     <a href="#secretpath" title="SecretPath">SecretPath</a>: <i>String</i>
-    <a href="#server" title="Server">Server</a>: <i>String</i>
     <a href="#secretenginemountpath" title="SecretEngineMountPath">SecretEngineMountPath</a>: <i>String</i>
-    <a href="#token" title="Token">Token</a>: <i>String</i>
     <a href="#secretlength" title="SecretLength">SecretLength</a>: <i>Integer</i>
 </pre>
 
@@ -45,16 +41,6 @@ _Type_: String
 
 _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
-#### Server
-
-The Vault server address. Like `https://vault.example.com/` for KV v2 secrets
-
-_Required_: Yes
-
-_Type_: String
-
-_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
-
 #### SecretEngineMountPath
 
 The secret engine's mount path. For example KV v2 might be `secret`
@@ -63,17 +49,7 @@ _Required_: Yes
 
 _Type_: String
 
-_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
-
-#### Token
-
-The Vault token to authorize to Vault with.
-
-_Required_: Yes
-
-_Type_: String
-
-_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 #### SecretLength
 

--- a/generic-vault-secret.json
+++ b/generic-vault-secret.json
@@ -2,7 +2,35 @@
     "typeName": "Generic::Vault::Secret",
     "description": "A resource to handle creating Vault secrets.",
     "sourceUrl": "https://github.com/RenovoSolutions/cfn-generic-vault-secrets.git",
-    "definitions": {},
+    "typeConfiguration": {
+        "properties": {
+            "VaultConnection": {
+                "$ref": "#/definitions/VaultConnection"
+            }
+        },
+        "additionalProperties": false
+    },
+    "definitions": {
+        "VaultConnection": {
+            "description": "Details needed to connect to Vault such as the URL and the token.",
+            "properties": {
+                "Token": {
+                    "description": "The Vault token to authorize to Vault with.",
+                    "type": "string"
+                },
+                "Server": {
+                    "description": "The Vault server address. Like `https://vault.example.com/` for KV v2 secrets",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Token",
+                "Server"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
     "properties": {
         "SecretPath": {
             "description": "Specify the secret path in Vault. This should be everything after the mount location in a path. For example `secret/some/path/to/somesecret` would be `some/path/to/somesecret`",
@@ -12,16 +40,8 @@
             "description": "Optional property to define secret data directly. If left blank the secret will be randomly generated and the key will be `value`. Like: `{\"data\": {\"value\": \"theSecretSecret\"}}`",
             "type": "string"
         },
-        "Server": {
-            "description": "The Vault server address. Like `https://vault.example.com/` for KV v2 secrets",
-            "type": "string"
-        },
         "SecretEngineMountPath": {
             "description": "The secret engine's mount path. For example KV v2 might be `secret`",
-            "type": "string"
-        },
-        "Token": {
-            "description": "The Vault token to authorize to Vault with.",
             "type": "string"
         },
         "SecretLength": {
@@ -37,20 +57,27 @@
     "additionalProperties": false,
     "required": [
         "SecretPath",
-        "Server",
-        "SecretEngineMountPath",
-        "Token"
+        "SecretEngineMountPath"
     ],
     "createOnlyProperties": [
-        "/properties/SecretPath"
+        "/properties/SecretPath",
+        "/properties/SecretEngineMountPath"
     ],
     "readOnlyProperties": [
         "/properties/Version",
         "/properties/SecretData"
     ],
     "primaryIdentifier": [
+        "/properties/SecretEngineMountPath",
         "/properties/SecretPath",
         "/properties/Version"
+    ],
+    "additionalIdentifiers": [
+        [
+            "/properties/Server",
+            "/properties/SecretEngineMountPath",
+            "/properties/Token"
+        ]
     ],
     "handlers": {
         "create": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-cloudformation-cli-python-lib>=2.1.3
+cloudformation-cli-python-lib
+cloudformation-cli

--- a/src/generic_vault_secret/models.py
+++ b/src/generic_vault_secret/models.py
@@ -35,15 +35,14 @@ class ResourceHandlerRequest(BaseResourceHandlerRequest):
     # pylint: disable=invalid-name
     desiredResourceState: Optional["ResourceModel"]
     previousResourceState: Optional["ResourceModel"]
+    typeConfiguration: Optional["TypeConfigurationModel"]
 
 
 @dataclass
 class ResourceModel(BaseModel):
     SecretPath: Optional[str]
     SecretData: Optional[str]
-    Server: Optional[str]
     SecretEngineMountPath: Optional[str]
-    Token: Optional[str]
     SecretLength: Optional[int]
     Version: Optional[int]
 
@@ -59,9 +58,7 @@ class ResourceModel(BaseModel):
         return cls(
             SecretPath=json_data.get("SecretPath"),
             SecretData=json_data.get("SecretData"),
-            Server=json_data.get("Server"),
             SecretEngineMountPath=json_data.get("SecretEngineMountPath"),
-            Token=json_data.get("Token"),
             SecretLength=json_data.get("SecretLength"),
             Version=json_data.get("Version"),
         )


### PR DESCRIPTION
AWS recently introduced type configurations for registered cloudformation providers. This changes implementation pretty significantly. This is the first pass at making this provider work with type configuration.

Its currently unclear how testing works with type configuration and some details are still returning as blank that are needed for create and read operations so this provider is still a WIP